### PR TITLE
Add missing dependency for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ libcurl4-openssl-dev uuid-dev icu-devtools libicu-dev
 ### Fedora
 
 ```sh
-sudo dnf install openssl-devel readline-devel zlib-devel libcurl-devel uuid-devel libuuid-devel
+sudo dnf install openssl-devel readline-devel zlib-devel libcurl-devel uuid-devel libuuid-devel perl-FindBin
 ```
 
 ### (open)SUSE


### PR DESCRIPTION
If FindBin is not installed, postgres installation fails with:

> Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC entries checked: /usr/local/lib64/perl5/5.40 /usr/local/share/perl5/5.40 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../../../src/backend/catalog/genbki.pl line 20.